### PR TITLE
Call mkarchiso with archiso profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 
 build-iso:
 	$(eval TMPDIR := $(shell mktemp -d))
-	(cd $(TMPDIR) && sudo GNUPGHOME=$(HOME)/.gnupg /usr/share/archiso/configs/releng/build.sh -g $(GPGKEY))
+	(cd $(TMPDIR) && sudo GNUPGHOME=$(HOME)/.gnupg mkarchiso -g $(GPGKEY) /usr/share/archiso/configs/releng/)
 	cp $(TMPDIR)/out/archlinux-$(VERSION)-x86_64.iso .
 	sudo rm -rf $(TMPDIR)
 


### PR DESCRIPTION
**Makefile**:

With archiso v47 the build.sh scripts of the profiles are deprecated
(and will be removed with archiso v49).

The mkarchiso script has gained the capability to be provided (by
parameter) with a profile directory to build from.

NOTE: please only merge after archiso v47 is released and packaged.