### PR TITLE
Change names of initramfs and img

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ build-netboot:
 		-f archlinux-$(VERSION)-x86_64.iso \
 		arch/
 	chmod +w arch/boot/{,x86_64}
-	for f in arch/boot/amd-ucode.img arch/boot/intel-ucode.img arch/boot/x86_64/vmlinuz-linux arch/boot/x86_64/archiso.img; do \
+	for f in arch/boot/amd-ucode.img arch/boot/intel-ucode.img arch/boot/x86_64/vmlinuz-* arch/boot/x86_64/initramfs-*.img; do \
 		$(VENDOR)/arch_netboot_tools/codesigning/sign_file.sh $$f \
 			$(CURDIR)/codesign.crt \
 			$(CURDIR)/codesign.key; \
@@ -48,7 +48,7 @@ upload-release:
 	cd vendor/archlinux-docker && $(MAKE) docker-push
 
 show-info:
-	@file arch/boot/x86_64/vmlinuz-linux | grep -P -o 'version [^-]*'
+	@file arch/boot/x86_64/vmlinuz-* | grep -P -o 'version [^-]*'
 	@grep archlinux-$(VERSION)-x86_64.iso sha1sums.txt
 	@grep archlinux-$(VERSION)-x86_64.iso md5sums.txt
 


### PR DESCRIPTION
Makefile:
With https://gitlab.archlinux.org/archlinux/archiso/-/merge_requests/74
the naming scheme of the initramfs is not hardcoded (i.e. archiso.img)
anymore but follows the standard naming scheme (i.e. initramfs-linux.img
when using the standard linux kernel package).
Additionally, this change now allows more than one kernel to be
installed, which is why the vmlinuz image also should be more
generically approached in scripting.