### PR TITLE
Create zsync control file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VENDOR := $(CURDIR)/vendor
 VERSION := $(shell date +%Y.%m.%d)
 GPGKEY := 4AA4767BBC9C4B1D18AE28B77F2D434B9741E8AC
 
-all: build-iso build-netboot build-bootstrap create-signatures create-torrent show-info
+all: build-iso build-netboot build-bootstrap create-signatures create-torrent create-zsync-control show-info
 
 clean:
 	git clean -xdf -e .idea -e codesign.crt -e codesign.key
@@ -43,6 +43,9 @@ create-signatures:
 create-torrent:
 	$(VENDOR)/archlinux-torrent-utils/mktorrent-archlinux $(VERSION) archlinux-$(VERSION)-x86_64.iso
 
+create-zsync-control:
+	zsyncmake -C -u archlinux-$(VERSION)-x86_64.iso archlinux-$(VERSION)-x86_64.iso
+
 upload-release:
 	rsync -cah --progress \
 		archlinux-$(VERSION)-x86_64.iso* md5sums.txt sha1sums.txt arch archlinux-bootstrap-$(VERSION)-x86_64.tar.gz* \
@@ -60,4 +63,4 @@ copy-torrent:
 run-iso:
 	qemu-system-x86_64 -boot d -m 4G -enable-kvm -device intel-hda -device hda-duplex -smp cores=2,threads=2 -cdrom archlinux-$(VERSION)-x86_64.iso
 
-.PHONY: all clean build-iso build-netboot build-bootstrap create-signatures create-torrent upload-release show-info copy-torrent run-iso
+.PHONY: all clean build-iso build-netboot build-bootstrap create-signatures create-torrent create-zsync-control upload-release show-info copy-torrent run-iso


### PR DESCRIPTION
Add a Makefile step to create a zsync control file.

This is a small file containing hashes of blocks that can be used by zsync to download a delta based on a previously downloaded file. This approach works on any HTTP server that supports download ranges. In the case of archiso it can reduce data download by 40-50%, and will use any older image as a seed file with no additional effort:

```
zsync -i archlinux-2020.12.01-x86_64.iso http://archlinux.mirror/iso/2021.03.01/archlinux-2021.03.01-x86_64.iso.zsync
```

However, it does require the `zsyncmake` executable to be available on the host (via the `zsync` package).