### PR TITLE
Create a predictable symlink to the latest ISO signature

### DIFF
--- a/justfile
+++ b/justfile
@@ -85,6 +85,7 @@ create-signatures:
 # create a latest symlink
 latest-symlink:
 	ln -sf "archlinux-${VERSION}-x86_64.iso" "archlinux-x86_64.iso"
+	ln -sf "archlinux-${VERSION}-x86_64.iso.sig" "archlinux-x86_64.iso.sig"
 
 # create Torrent file
 create-torrent:
@@ -105,7 +106,7 @@ create-torrent:
 upload-release:
 	rsync -cah --progress \
 		"archlinux-${VERSION}-x86_64.iso"* md5sums.txt sha1sums.txt sha256sums.txt b2sums.txt arch "archlinux-bootstrap-${VERSION}-x86_64.tar.gz"* \
-		"archlinux-x86_64.iso" \
+		"archlinux-x86_64.iso" "archlinux-x86_64.iso.sig" \
 		-e ssh repos.archlinux.org:tmp/
 
 # show release information


### PR DESCRIPTION
This has no use for the mirrors, since none of the signatures on the mirrors can be trusted, but it will ensure the `archlinux-x86_64.iso.sig` symlink exists on archlinux.org.

For example, if the ISO is downloaded from https://geo.mirror.pkgbuild.com/iso/latest/archlinux-x86_64.iso, its matching signature could be safely downloaded from https://archlinux.org/iso/latest/archlinux-x86_64.iso.sig.

CC @jelly