### PR TITLE
Update torrent comment to use full URL and enclose it in angle brackets

### DIFF
--- a/justfile
+++ b/justfile
@@ -98,7 +98,7 @@ create-torrent:
 	echo 'Building torrent...'
 	mktorrent \
 		-l 19 \
-		-c "Arch Linux ${VERSION} (www.archlinux.org)" \
+		-c "Arch Linux ${VERSION} <https://archlinux.org>" \
 		${httpmirrorlist} \
 		"archlinux-${VERSION}-x86_64.iso"
 


### PR DESCRIPTION
Remove "`www.`" from archlinux.org.