### PR TITLE
Add archive.archlinux.org as a WebSeed

### DIFF
--- a/justfile
+++ b/justfile
@@ -107,6 +107,7 @@ create-torrent:
 		-l 19 \
 		-c "Arch Linux ${VERSION} <https://archlinux.org>" \
 		${httpmirrorlist} \
+		-w "https://archive.archlinux.org/iso/${VERSION}/" \
 		"archlinux-${VERSION}-x86_64.iso"
 
 # upload artifacts


### PR DESCRIPTION
This will ensure that old ISOs can be downloaded via BitTorrent even if there are no seeds.

archive.archlinux.org is placed as the last WebSeed in the naive hope that others would get tried first.