### PR TITLE
Give the alpm user access to the archiso work directory

### DIFF
--- a/justfile
+++ b/justfile
@@ -20,6 +20,8 @@ build:
     set -euo pipefail
 
     TMPDIR=$(mktemp -d -t archiso-manager-build.XXXXXXXXXX)
+    chown :alpm "$TMPDIR"
+    chmod g+rx "$TMPDIR"
     sudo mkarchiso \
     	-c "{{ justfile_directory() }}/codesign.crt {{ justfile_directory() }}/codesign.key" \
     	-m 'iso netboot bootstrap' \


### PR DESCRIPTION
`mktemp -d` creates the directory with `0700` permissions so only the owner can access it, but since
https://gitlab.archlinux.org/archlinux/archiso/-/commit/691c57fc2e6345d0a2fbfffd7b6689b14bb87f7b the `alpm` user needs to have access to it too.

Related to https://gitlab.archlinux.org/archlinux/archiso/-/issues/232