### PR TITLE
Test the ISO in UEFI mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Install required packages
 ```sh
-pacman -Syu --needed just archiso rsync mktorrent
+pacman -Syu --needed just archiso edk2-ovmf rsync mktorrent
 ```
 
 ### Configure your signing keys

--- a/justfile
+++ b/justfile
@@ -152,7 +152,7 @@ copy-torrent:
 
 # test the ISO image
 run-iso:
-    run_archiso -i "archlinux-{{ VERSION }}-x86_64.iso"
+    run_archiso -u -i "archlinux-{{ VERSION }}-x86_64.iso"
 
 # check mirror status for specified version or latest release
 check-mirrors *version:


### PR DESCRIPTION
All systems from the past decade have UEFI. It is best to test the boot methods that actually matter.

This requires the edk2-ovmf package.